### PR TITLE
Include feedback from call

### DIFF
--- a/pretix_ticket_request/forms.py
+++ b/pretix_ticket_request/forms.py
@@ -188,6 +188,8 @@ class TicketRequestForm(forms.ModelForm):
         saved = super().save(commit=commit)
 
         locale = 'en'
+        email = self.instance.email
+        name = self.instance.name
 
         if saved:
             with language(locale):
@@ -202,11 +204,11 @@ Your {event} team"""))
 
                 email_context = {
                     'event': event,
-                    'name': self.instance.name
+                    'name': name
                 }
 
                 mail(
-                    self.email,
+                    email,
                     _('Your {event} ticket request').format(event=str(event)),
                     email_content,
                     email_context,

--- a/pretix_ticket_request/forms.py
+++ b/pretix_ticket_request/forms.py
@@ -40,6 +40,7 @@ class TicketRequestsSettingsForm(I18nForm, SettingsForm):
 
 
 class TicketRequestForm(forms.ModelForm):
+    required_css_class = 'required'
     name = forms.CharField(
         label=_("Full name"),
         required=True,
@@ -152,19 +153,31 @@ class TicketRequestForm(forms.ModelForm):
         required=False,
     )
 
-    follow_coc = forms.BooleanField(
+    follow_coc = forms.TypedChoiceField(
         label=_("Do you agree to respect and follow IFF’s Code of Conduct?"),
         required=True,
+        choices=(
+            ((True, 'Yes'), (False, 'No'))
+        ),
+        widget=forms.RadioSelect
     )
 
-    subscribe_mailing_list = forms.BooleanField(
+    subscribe_mailing_list = forms.TypedChoiceField(
         label=_("Would you like to subscribe to the IFF Mailing List?"),
         required=False,
+        choices=(
+            ((True, 'Yes'), (False, 'No'))
+        ),
+        widget=forms.RadioSelect
     )
 
-    receive_mattermost_invite = forms.BooleanField(
+    receive_mattermost_invite = forms.TypedChoiceField(
         label=_("Would you like to receive a Mattermost invite?"),
         required=False,
+        choices=(
+            ((True, 'Yes'), (False, 'No'))
+        ),
+        widget=forms.RadioSelect
     )
 
     def __init__(self, *args, **kwargs):
@@ -178,8 +191,15 @@ class TicketRequestForm(forms.ModelForm):
                 if meta_json.get(field):
                     self.fields[field].initial = meta_json.get(field)
 
+    def clean_follow_coc(self):
+        follow_coc = self.cleaned_data.get('follow_coc')
+
+        if not follow_coc == 'True':
+            raise forms.ValidationError("You have to agree to respect and follow IFF’s Code of Conduct")
+
+        return follow_coc
+
     def save(self, commit=True):
-        event = self.event
         meta_json = self.instance.data
         for field in self.Meta.json_fields:
             meta_json[field] = self.cleaned_data[field]
@@ -187,13 +207,23 @@ class TicketRequestForm(forms.ModelForm):
 
         saved = super().save(commit=commit)
 
-        locale = 'en'
-        email = self.instance.email
-        name = self.instance.name
-
         if saved:
-            with language(locale):
-                email_content = LazyI18nString.from_gettext(ugettext_noop("""Dear {name} ,
+            event = self.event
+            email = self.instance.email
+            name = self.instance.name
+
+            self._send_confirmation_email(email=email, name=name, event=event)
+
+        return saved
+
+    def _send_confirmation_email(self, *args, **kwargs):
+        locale = 'en'
+        email = kwargs.pop('email')
+        name = kwargs.pop('name')
+        event = kwargs.pop('event')
+
+        with language(locale):
+            email_content = LazyI18nString.from_gettext(ugettext_noop("""Dear {name} ,
 
 Thank you for applying for an IFF Ticket. We are currently reviewing ticket requests, and as space becomes available, we will be issuing tickets.
 
@@ -202,21 +232,19 @@ If you have any questions, please email team@internetfreedomfestival.org
 Best regards,
 Your {event} team"""))
 
-                email_context = {
-                    'event': event,
-                    'name': name
-                }
+            email_context = {
+                'event': event,
+                'name': name
+            }
 
-                mail(
-                    email,
-                    _('Your {event} ticket request').format(event=str(event)),
-                    email_content,
-                    email_context,
-                    event,
-                    locale=locale
-                )
-
-        return saved
+            mail(
+                email,
+                _('Your {event} ticket request').format(event=str(event)),
+                email_content,
+                email_context,
+                event,
+                locale=locale
+            )
 
     class Meta:
         model = TicketRequest
@@ -391,19 +419,31 @@ class AttendeeProfileForm(forms.Form):
         required=False,
     )
 
-    follow_coc = forms.BooleanField(
+    follow_coc = forms.TypedChoiceField(
         label=_("Do you agree to respect and follow IFF’s Code of Conduct?"),
         required=True,
+        choices=(
+            ((True, 'Yes'), (False, 'No'))
+        ),
+        widget=forms.RadioSelect
     )
 
-    subscribe_mailing_list = forms.BooleanField(
+    subscribe_mailing_list = forms.TypedChoiceField(
         label=_("Would you like to subscribe to the IFF Mailing List?"),
         required=False,
+        choices=(
+            ((True, 'Yes'), (False, 'No'))
+        ),
+        widget=forms.RadioSelect
     )
 
-    receive_mattermost_invite = forms.BooleanField(
+    receive_mattermost_invite = forms.TypedChoiceField(
         label=_("Would you like to receive a Mattermost invite?"),
         required=False,
+        choices=(
+            ((True, 'Yes'), (False, 'No'))
+        ),
+        widget=forms.RadioSelect
     )
 
     def __init__(self, *args, **kwargs):
@@ -549,19 +589,31 @@ class AttendeeDetailForm(forms.ModelForm):
         required=False,
     )
 
-    follow_coc = forms.BooleanField(
+    follow_coc = forms.TypedChoiceField(
         label=_("Do you agree to respect and follow IFF’s Code of Conduct?"),
         required=True,
+        choices=(
+            ((True, 'Yes'), (False, 'No'))
+        ),
+        widget=forms.RadioSelect
     )
 
-    subscribe_mailing_list = forms.BooleanField(
+    subscribe_mailing_list = forms.TypedChoiceField(
         label=_("Would you like to subscribe to the IFF Mailing List?"),
         required=False,
+        choices=(
+            ((True, 'Yes'), (False, 'No'))
+        ),
+        widget=forms.RadioSelect
     )
 
-    receive_mattermost_invite = forms.BooleanField(
+    receive_mattermost_invite = forms.TypedChoiceField(
         label=_("Would you like to receive a Mattermost invite?"),
         required=False,
+        choices=(
+            ((True, 'Yes'), (False, 'No'))
+        ),
+        widget=forms.RadioSelect
     )
 
     def __init__(self, *args, **kwargs):

--- a/pretix_ticket_request/models.py
+++ b/pretix_ticket_request/models.py
@@ -1,5 +1,6 @@
 from django.core.validators import RegexValidator
 from django.db import models, transaction
+from django_countries.fields import Country
 from django.utils.translation import (
     pgettext_lazy, ugettext_lazy as _, ugettext_noop,
 )
@@ -76,6 +77,10 @@ class TicketRequest(LoggedModel):
         self.status = TicketRequest.STATUS_REJECTED
         self.log_action('pretix.ticket_request.rejected', user=user)
         self.save()
+
+    @property
+    def country(self):
+        return Country(code=self.data.get('country'))
 
     def send_voucher(self, quota_cache=None, user=None):
         event = self.event

--- a/pretix_ticket_request/signals.py
+++ b/pretix_ticket_request/signals.py
@@ -1,11 +1,12 @@
 from django.db.models import QuerySet
 from django.dispatch import receiver
+from django.template.loader import get_template
 from django.urls import resolve, reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext_lazy as _, get_language
 from i18nfield.strings import LazyI18nString
 from django.utils.functional import cached_property
 from pretix.control.signals import nav_event
-from pretix.presale.signals import checkout_flow_steps
+from pretix.presale.signals import (checkout_flow_steps, front_page_bottom)
 
 from . import views
 
@@ -73,3 +74,8 @@ def verify_account_checkout_step(sender, **kwargs):
 @receiver(checkout_flow_steps, dispatch_uid='pretix_ticket_request_your_profile_checkout_step')
 def your_profile_checkout_step(sender, **kwargs):
     return views.AttendeeProfileStep
+
+
+@receiver(front_page_bottom, dispatch_uid="pretix_ticket_request_frontpage_link")
+def pretixpresale_front_page_bottom(sender, **kwargs):
+    return get_template('pretix_ticket_request/front_page.html').render({'event': sender, 'organizer': sender.organizer})

--- a/pretix_ticket_request/templates/pretix_ticket_request/fragment_status.html
+++ b/pretix_ticket_request/templates/pretix_ticket_request/fragment_status.html
@@ -1,12 +1,12 @@
 {% load i18n %}
 {% load bootstrap3 %}
-{% if ticket_request.status == "pending" %}
+{% if status == "pending" %}
     <span data-toggle="tooltip" title="{{ ticket_request.created_at|date:"SHORT_DATETIME_FORMAT" }}"
             class="label label-warning {{ class }}">{% trans "Pending" %}</span>
-{% elif ticket_request.status == "approved" %}
+{% elif status == "approved" %}
     <span class="label label-success {{ class }}">{% trans "Approved" %}</span>
-{% elif ticket_request.status == "rejected" %}
+{% elif status == "rejected" %}
     <span class="label label-danger {{ class }}">{% trans "Rejected" %}</span>
-{% elif ticket_request.status == "withdrawn" %}
+{% elif status == "withdrawn" %}
     <span class="label label-danger {{ class }}">{% trans "Withdrawn" %}</span>
 {% endif %}

--- a/pretix_ticket_request/templates/pretix_ticket_request/front_page.html
+++ b/pretix_ticket_request/templates/pretix_ticket_request/front_page.html
@@ -1,0 +1,20 @@
+{% load i18n %}
+{% load eventurl %}
+<section class="front-page">
+  <h3>{% trans "If you don't have a voucher" %}</h3>
+  <div>
+      <div class="col-md-8 col-xs-12">
+          <p>
+              {% blocktrans trimmed %}
+                  If you want to get a ticket to attent IFF, click on the following button.
+              {% endblocktrans %}
+          </p>
+      </div>
+      <div class="col-md-4 col-xs-12">
+          <a class="btn btn-block btn-primary" href="{% url "plugins:pretix_ticket_request:request" organizer=organizer.slug event=event.slug %}">
+              {% trans "Request a ticket" %}
+          </a>
+      </div>
+      <div class="clearfix"></div>
+  </div>
+</section>

--- a/pretix_ticket_request/templates/pretix_ticket_request/index.html
+++ b/pretix_ticket_request/templates/pretix_ticket_request/index.html
@@ -23,8 +23,9 @@
                 <thead>
                 <tr>
                     <th>{% trans "Email" %}</th>
-                    <th>{% trans "Status" %}</th>
+                    <th>{% trans "Country" %}</th>
                     <th>{% trans "Date" %}</th>
+                    <th>{% trans "Status" %}</th>
                     <th>{% trans "Voucher" %}</th>
                     <th></th>
                 </tr>
@@ -35,10 +36,14 @@
                         <td>
                             <strong><a href="{% url "plugins:pretix_ticket_request:update" organizer=request.event.organizer.slug event=request.event.slug ticket_request=tr.id %}">{{ tr.email }}</a></strong>
                         </td>
-                        <td class="text-left">{% include "pretix_ticket_request/fragment_status.html" with form=form %}</td>
+                        <td>
+                            <img src="{{tr.country.flag}}" alt="{{tr.country.name}}"/>
+                            {{ tr.country.name }}
+                        </td>
                         <td>
                             {{ tr.created_at|date:"SHORT_DATETIME_FORMAT" }}
                         </td>
+                        <td class="text-left">{% include "pretix_ticket_request/fragment_status.html" with status=tr.status %}</td>
                         <td>
                             {% if tr.voucher %}
                                 <strong>

--- a/pretix_ticket_request/templates/pretix_ticket_request/request.html
+++ b/pretix_ticket_request/templates/pretix_ticket_request/request.html
@@ -6,7 +6,7 @@
 {% block title %}{% trans "Ticket Request" %}{% endblock %}
 {% block content %}
     <h2>{% trans "Ticket Request" %}</h2>
-    <p>{% trans "Complete the form below to be get into the waiting list. We will review your application and will get a ticket if approved." %}</p>
+    <p>{% trans "Complete the form to request a ticket to the IFF. Once you complete the form, your request will be reviewed by the IFF team, and as space becomes available, tickets will be released." %}</p>
     <form class="form-horizontal" method="post" enctype="multipart/form-data">
         {% csrf_token %}
         {% bootstrap_form_errors form type='non_fields' %}

--- a/pretix_ticket_request/views.py
+++ b/pretix_ticket_request/views.py
@@ -155,7 +155,7 @@ class TicketRequestCreate(FormView):
         form.instance.event = self.request.event
         form.save()
 
-        messages.success(self.request, _('Your request has been saved. We will email you if you are approved.'))
+        messages.success(self.request, _('Your request has been saved. A confirmation email was sent.'))
 
         return super().form_valid(form)
 

--- a/pretix_ticket_request/views.py
+++ b/pretix_ticket_request/views.py
@@ -136,6 +136,11 @@ class TicketRequestCreate(FormView):
     form_class = forms.TicketRequestForm
     template_name = 'pretix_ticket_request/request.html'
 
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs['event'] = self.request.event
+        return kwargs
+
     def get_success_url(self):
         return reverse(
             'plugins:pretix_ticket_request:request',

--- a/pretix_ticket_request/views.py
+++ b/pretix_ticket_request/views.py
@@ -238,6 +238,8 @@ class VerifyAccountStep(CartMixin, TemplateFlowStep):
             self.cart_session['verification_code_matches'] = False
             self.cart_session['verification_email_sent'] = True
 
+            messages.success(request, _('New verification code sent.'))
+
             return redirect(request.build_absolute_uri(request.path))
 
         if self.cart_session.get('verification_email_sent'):


### PR DESCRIPTION
This PR implements the pending items from the feedback call.

- Change email and form copy
- Change required checkboxes to be Yes/No questions
- Use `required_css_class` in forms
- Render status and country in ticket request list
- Show ticket request link in checkout front page
- Display message after resending a verification code.
- Send ticket request confirmation email